### PR TITLE
feat: support Windows

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -6,8 +6,9 @@ return {
 		})
 
 		if event == 1 then
+			local s = ya.target_family() == "windows" and ' %*' or ' "$@"'
 			ya.manager_emit("shell", {
-				value .. ' "$@"',
+				value .. s,
 				orphan = true,
 				confirm = true,
 			})


### PR DESCRIPTION
Windows should use `%*` instead of `"$@"`, https://yazi-rs.github.io/docs/configuration/keymap#manager.shell